### PR TITLE
Update solidity-parser version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-  - '0.12'
   - '4'
   - '5'
   - '6'
+  - '7'
 notifications:
   email: false
 sudo: false

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "get-stdin-promise": "*",
     "graphlib": "^2.1.0",
     "graphlib-dot": "^0.6.2",
-    "solidity-parser": "0.1.0"
+    "solidity-parser": "0.3.0"
   }
 }


### PR DESCRIPTION
The version 0.1.0 of solidity parser had issues with pragmas which is a blocker for recent contracts.
Bumping up the solidity-parser solves this problem.
